### PR TITLE
refactor: update prisma types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,24 +1,24 @@
 {
   "name": "prisma-schema-dsl",
-  "version": "2.0.5",
+  "version": "2.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "prisma-schema-dsl",
-      "version": "2.0.5",
+      "version": "2.0.4",
       "license": "MIT",
       "dependencies": {
         "@prisma/internals": "^4.6.1",
         "@types/lodash.isempty": "^4.4.6",
         "lodash.isempty": "^4.4.0",
-        "prisma-schema-dsl-types": "^1.0.7",
         "typescript": "^4.1.3"
       },
       "devDependencies": {
         "@types/jest": "^26.0.19",
         "jest": "^26.6.3",
         "prettier": "^2.2.1",
+        "prisma-schema-dsl-types": "^1.0.8",
         "ts-jest": "^26.4.4",
         "ts-toolbelt": "^9.6.0"
       }
@@ -5571,9 +5571,10 @@
       }
     },
     "node_modules/prisma-schema-dsl-types": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/prisma-schema-dsl-types/-/prisma-schema-dsl-types-1.0.7.tgz",
-      "integrity": "sha512-AH7iz43Z+STOCuHjkBYD9rb3B4hxon9CDh7qqNIZt/OVsQxIVr8hOCIiNgFFDTd4Iw7QR88Vzvh3yiMlsveUUQ==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/prisma-schema-dsl-types/-/prisma-schema-dsl-types-1.0.8.tgz",
+      "integrity": "sha512-rR/3abzaev62MX7UMJWBIcFXG2oE/epGPR3pa64GoTGs4N2z6kMkF1RmMezvYoexM+UGYkcQQgYljkQcvzwmSA==",
+      "dev": true,
       "dependencies": {
         "typescript": "^4.9.3"
       }
@@ -12061,9 +12062,10 @@
       }
     },
     "prisma-schema-dsl-types": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/prisma-schema-dsl-types/-/prisma-schema-dsl-types-1.0.7.tgz",
-      "integrity": "sha512-AH7iz43Z+STOCuHjkBYD9rb3B4hxon9CDh7qqNIZt/OVsQxIVr8hOCIiNgFFDTd4Iw7QR88Vzvh3yiMlsveUUQ==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/prisma-schema-dsl-types/-/prisma-schema-dsl-types-1.0.8.tgz",
+      "integrity": "sha512-rR/3abzaev62MX7UMJWBIcFXG2oE/epGPR3pa64GoTGs4N2z6kMkF1RmMezvYoexM+UGYkcQQgYljkQcvzwmSA==",
+      "dev": true,
       "requires": {
         "typescript": "^4.9.3"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prisma-schema-dsl",
-  "version": "2.0.4",
+  "version": "2.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "prisma-schema-dsl",
-      "version": "2.0.4",
+      "version": "2.0.7",
       "license": "MIT",
       "dependencies": {
         "@prisma/internals": "^4.6.1",

--- a/package.json
+++ b/package.json
@@ -26,13 +26,13 @@
     "@prisma/internals": "^4.6.1",
     "@types/lodash.isempty": "^4.4.6",
     "lodash.isempty": "^4.4.0",
-    "prisma-schema-dsl-types": "^1.0.7",
     "typescript": "^4.1.3"
   },
   "devDependencies": {
     "@types/jest": "^26.0.19",
     "jest": "^26.6.3",
     "prettier": "^2.2.1",
+    "prisma-schema-dsl-types": "^1.0.8",
     "ts-jest": "^26.4.4",
     "ts-toolbelt": "^9.6.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-schema-dsl",
-  "version": "2.0.5",
+  "version": "2.0.7",
   "description": "JavaScript interface for Prisma Schema DSL",
   "main": "dist/index.js",
   "scripts": {

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -9,7 +9,6 @@ import {
   DataSourceProvider,
   DataSourceURLEnv,
   Generator,
-  CallExpression,
   CUID,
   AUTO_INCREMENT,
   NOW,
@@ -17,6 +16,7 @@ import {
   ScalarFieldDefault,
   Enum,
   ReferentialActions,
+  isCallExpression,
 } from "prisma-schema-dsl-types";
 
 const NAME_REGEXP = /[A-Za-z][A-Za-z0-9_]*/;
@@ -111,7 +111,7 @@ function validateScalarDefault(type: ScalarType, value: ScalarFieldDefault) {
       if (
         !(
           typeof value === "string" ||
-          (value instanceof CallExpression &&
+          (isCallExpression(value) &&
             (value.callee === UUID || value.callee === CUID))
         )
       ) {
@@ -131,7 +131,7 @@ function validateScalarDefault(type: ScalarType, value: ScalarFieldDefault) {
       if (
         !(
           typeof value === "number" ||
-          (value instanceof CallExpression && value.callee === AUTO_INCREMENT)
+          (isCallExpression(value) && value.callee === AUTO_INCREMENT)
         )
       ) {
         throw new Error(
@@ -150,7 +150,7 @@ function validateScalarDefault(type: ScalarType, value: ScalarFieldDefault) {
       if (
         !(
           typeof value === "string" ||
-          (value instanceof CallExpression && value.callee === NOW)
+          (isCallExpression(value) && value.callee === NOW)
         )
       ) {
         throw new Error(

--- a/src/print.spec.ts
+++ b/src/print.spec.ts
@@ -24,7 +24,6 @@ import {
   DataSourceProvider,
   Model,
   Generator,
-  CallExpression,
   AUTO_INCREMENT,
   UUID,
   CUID,
@@ -174,7 +173,7 @@ describe("printField", () => {
         false,
         false,
         false,
-        new CallExpression(AUTO_INCREMENT)
+        {callee: AUTO_INCREMENT}
       ),
       `${EXAMPLE_FIELD_NAME} ${ScalarType.Int} @default(autoincrement())`,
     ],
@@ -188,7 +187,7 @@ describe("printField", () => {
         false,
         false,
         false,
-        new CallExpression(UUID)
+        {callee: UUID}
       ),
       `${EXAMPLE_FIELD_NAME} ${ScalarType.String} @default(uuid())`,
     ],
@@ -202,7 +201,7 @@ describe("printField", () => {
         false,
         false,
         false,
-        new CallExpression(CUID)
+        {callee: CUID}
       ),
       `${EXAMPLE_FIELD_NAME} ${ScalarType.String} @default(cuid())`,
     ],
@@ -216,7 +215,7 @@ describe("printField", () => {
         false,
         false,
         false,
-        new CallExpression(NOW)
+        {callee: NOW}
       ),
       `${EXAMPLE_FIELD_NAME} ${ScalarType.DateTime} @default(now())`,
     ],

--- a/src/print.spec.ts
+++ b/src/print.spec.ts
@@ -173,7 +173,7 @@ describe("printField", () => {
         false,
         false,
         false,
-        {callee: AUTO_INCREMENT}
+        { callee: AUTO_INCREMENT }
       ),
       `${EXAMPLE_FIELD_NAME} ${ScalarType.Int} @default(autoincrement())`,
     ],
@@ -187,7 +187,7 @@ describe("printField", () => {
         false,
         false,
         false,
-        {callee: UUID}
+        { callee: UUID }
       ),
       `${EXAMPLE_FIELD_NAME} ${ScalarType.String} @default(uuid())`,
     ],
@@ -201,7 +201,7 @@ describe("printField", () => {
         false,
         false,
         false,
-        {callee: CUID}
+        { callee: CUID }
       ),
       `${EXAMPLE_FIELD_NAME} ${ScalarType.String} @default(cuid())`,
     ],
@@ -215,7 +215,7 @@ describe("printField", () => {
         false,
         false,
         false,
-        {callee: NOW}
+        { callee: NOW }
       ),
       `${EXAMPLE_FIELD_NAME} ${ScalarType.DateTime} @default(now())`,
     ],

--- a/src/print.ts
+++ b/src/print.ts
@@ -10,7 +10,6 @@ import {
   FieldKind,
   BaseField,
   Generator,
-  CallExpression,
   isCallExpression,
   ScalarFieldDefault,
   Enum,

--- a/src/print.ts
+++ b/src/print.ts
@@ -2,6 +2,7 @@ import isEmpty from "lodash.isempty";
 import {
   Schema,
   DataSource,
+  isDataSourceURLEnv,
   DataSourceURLEnv,
   Model,
   ObjectField,
@@ -10,6 +11,7 @@ import {
   BaseField,
   Generator,
   CallExpression,
+  isCallExpression,
   ScalarFieldDefault,
   Enum,
   DataSourceProvider,
@@ -62,7 +64,7 @@ export function printDataSource(dataSource: DataSource): string {
 }
 
 function printDataSourceURL(url: string | DataSourceURLEnv): string {
-  return typeof url === "string" ? `"${url}"` : `env("${url.name}")`;
+  return isDataSourceURLEnv(url) ? `env("${url.name}")` : `"${url}"`;
 }
 
 export function printGenerator(generator: Generator): string {
@@ -206,7 +208,7 @@ function printScalarDefault(value: ScalarFieldDefault): string {
   if (typeof value === "number") {
     return String(value);
   }
-  if (value instanceof CallExpression) {
+  if (isCallExpression(value)) {
     return `${value.callee}()`;
   }
   throw new Error(`Invalid value: ${value}`);


### PR DESCRIPTION
Related to https://github.com/amplication/amplication/issues/4997

Depends on https://github.com/amplication/prisma-schema-dsl-types/pull/2

Update types for increased consistency and to avoid exporting classes in a types library