### PR TITLE
feat(@@map): added support for model @@map

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@prisma/internals": "^4.6.1",
         "@types/lodash.isempty": "^4.4.6",
         "lodash.isempty": "^4.4.0",
-        "prisma-schema-dsl-types": "^1.0.5",
+        "prisma-schema-dsl-types": "^1.0.7",
         "typescript": "^4.1.3"
       },
       "devDependencies": {
@@ -5571,9 +5571,9 @@
       }
     },
     "node_modules/prisma-schema-dsl-types": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/prisma-schema-dsl-types/-/prisma-schema-dsl-types-1.0.5.tgz",
-      "integrity": "sha512-kCEgIdJaea7lbhvfZvcm83o5XwkxRQQDvvWQJUPW0JHU1r4jXS4dNygNk57itPtegOFSypcDukKkqP3hJ/pEqA==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/prisma-schema-dsl-types/-/prisma-schema-dsl-types-1.0.7.tgz",
+      "integrity": "sha512-AH7iz43Z+STOCuHjkBYD9rb3B4hxon9CDh7qqNIZt/OVsQxIVr8hOCIiNgFFDTd4Iw7QR88Vzvh3yiMlsveUUQ==",
       "dependencies": {
         "typescript": "^4.9.3"
       }
@@ -12061,9 +12061,9 @@
       }
     },
     "prisma-schema-dsl-types": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/prisma-schema-dsl-types/-/prisma-schema-dsl-types-1.0.5.tgz",
-      "integrity": "sha512-kCEgIdJaea7lbhvfZvcm83o5XwkxRQQDvvWQJUPW0JHU1r4jXS4dNygNk57itPtegOFSypcDukKkqP3hJ/pEqA==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/prisma-schema-dsl-types/-/prisma-schema-dsl-types-1.0.7.tgz",
+      "integrity": "sha512-AH7iz43Z+STOCuHjkBYD9rb3B4hxon9CDh7qqNIZt/OVsQxIVr8hOCIiNgFFDTd4Iw7QR88Vzvh3yiMlsveUUQ==",
       "requires": {
         "typescript": "^4.9.3"
       }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@prisma/internals": "^4.6.1",
     "@types/lodash.isempty": "^4.4.6",
     "lodash.isempty": "^4.4.0",
-    "prisma-schema-dsl-types": "^1.0.5",
+    "prisma-schema-dsl-types": "^1.0.7",
     "typescript": "^4.1.3"
   },
   "devDependencies": {

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -56,13 +56,15 @@ export function createEnum(
 export function createModel(
   name: string,
   fields: Array<ScalarField | ObjectField>,
-  documentation?: string
+  documentation?: string,
+  map?: string
 ): Model {
   validateName(name);
   return {
     name,
     fields,
     documentation,
+    map,
   };
 }
 

--- a/src/print.spec.ts
+++ b/src/print.spec.ts
@@ -13,7 +13,8 @@ import {
   printModel,
   printGenerator,
   printEnum,
-  printDocumentation, printModelMap,
+  printDocumentation,
+  printModelMap,
 } from "./print";
 import {
   ScalarType,
@@ -62,7 +63,7 @@ const EXAMPLE_DATA_SOURCE_NAME = "exampleDataSource";
 const EXAMPLE_DATA_SOURCE_PROVIDER = DataSourceProvider.MySQL;
 const EXAMPLE_DATA_SOURCE_URL = "mysql://example.com";
 const EXAMPLE_RELATION_NAME = "exampleRelationName";
-const EXAMPLE_MODEL_MAP = 'ExampleMappedName';
+const EXAMPLE_MODEL_MAP = "ExampleMappedName";
 const POSTGRES_SQL_PROVIDER = DataSourceProvider.PostgreSQL;
 
 describe("printEnum", () => {
@@ -328,10 +329,10 @@ ${printField(EXAMPLE_OTHER_STRING_FIELD, POSTGRES_SQL_PROVIDER)}
     [
       "Single field and map",
       createModel(
-          EXAMPLE_MODEL_NAME,
-          [EXAMPLE_STRING_FIELD],
-          '',
-          EXAMPLE_MODEL_MAP
+        EXAMPLE_MODEL_NAME,
+        [EXAMPLE_STRING_FIELD],
+        "",
+        EXAMPLE_MODEL_MAP
       ),
       `model ${EXAMPLE_MODEL_NAME} {
 ${printField(EXAMPLE_STRING_FIELD, POSTGRES_SQL_PROVIDER)}

--- a/src/print.spec.ts
+++ b/src/print.spec.ts
@@ -13,7 +13,7 @@ import {
   printModel,
   printGenerator,
   printEnum,
-  printDocumentation,
+  printDocumentation, printModelMap,
 } from "./print";
 import {
   ScalarType,
@@ -62,6 +62,7 @@ const EXAMPLE_DATA_SOURCE_NAME = "exampleDataSource";
 const EXAMPLE_DATA_SOURCE_PROVIDER = DataSourceProvider.MySQL;
 const EXAMPLE_DATA_SOURCE_URL = "mysql://example.com";
 const EXAMPLE_RELATION_NAME = "exampleRelationName";
+const EXAMPLE_MODEL_MAP = 'ExampleMappedName';
 const POSTGRES_SQL_PROVIDER = DataSourceProvider.PostgreSQL;
 
 describe("printEnum", () => {
@@ -322,6 +323,20 @@ ${printField(EXAMPLE_STRING_FIELD, POSTGRES_SQL_PROVIDER)}
       `model ${EXAMPLE_MODEL_NAME} {
 ${printField(EXAMPLE_STRING_FIELD, POSTGRES_SQL_PROVIDER)}
 ${printField(EXAMPLE_OTHER_STRING_FIELD, POSTGRES_SQL_PROVIDER)}
+}`,
+    ],
+    [
+      "Single field and map",
+      createModel(
+          EXAMPLE_MODEL_NAME,
+          [EXAMPLE_STRING_FIELD],
+          '',
+          EXAMPLE_MODEL_MAP
+      ),
+      `model ${EXAMPLE_MODEL_NAME} {
+${printField(EXAMPLE_STRING_FIELD, POSTGRES_SQL_PROVIDER)}
+
+${printModelMap(EXAMPLE_MODEL_MAP)}
 }`,
     ],
   ];

--- a/src/print.ts
+++ b/src/print.ts
@@ -130,9 +130,11 @@ export function printModel(
   const fieldTexts = model.fields
     .map((field) => printField(field, provider))
     .join("\n");
+  const map = model.map ? printModelMap(model.map, true) : '';
+
   return withDocumentation(
     model.documentation,
-    `model ${model.name} {\n${fieldTexts}\n}`
+    `model ${model.name} {\n${fieldTexts}${map}\n}`
   );
 }
 
@@ -267,4 +269,10 @@ function printRelation(relation: Relation, field: ObjectField): string {
   ]
     .filter(Boolean)
     .join(", ")})`;
+}
+
+export function printModelMap(name: string, prependNewLines = false) {
+  const prefix = prependNewLines ? '\n\n': '';
+
+  return `${prefix}@@map("${name}")`;
 }

--- a/src/print.ts
+++ b/src/print.ts
@@ -130,7 +130,7 @@ export function printModel(
   const fieldTexts = model.fields
     .map((field) => printField(field, provider))
     .join("\n");
-  const map = model.map ? printModelMap(model.map, true) : '';
+  const map = model.map ? printModelMap(model.map, true) : "";
 
   return withDocumentation(
     model.documentation,
@@ -272,7 +272,7 @@ function printRelation(relation: Relation, field: ObjectField): string {
 }
 
 export function printModelMap(name: string, prependNewLines = false) {
-  const prefix = prependNewLines ? '\n\n': '';
+  const prefix = prependNewLines ? "\n\n" : "";
 
   return `${prefix}@@map("${name}")`;
 }


### PR DESCRIPTION
## Change included
**This PR depends on https://github.com/amplication/prisma-schema-dsl-types/pull/3**

This pull request adds support for the @@map property of Prisma, allowing models in the schema to be mapped to custom database table names. The 'map' parameter has been added to the createModel function after the 'documentation' parameter, preserving backwards compatibility with existing code.

As a suggestion for the future, it may be worth considering moving towards a single object parameter pattern. This change would enable the addition of new parameters without breaking existing code, while still supporting the current multiple-parameter signature. The updated code could look like this:
```ts
interface CreateModelOptions {
  name: string,
  fields: Array<ScalarField | ObjectField>,
  documentation?: string,
  map?: string
}
// overloads
export function createModel(name: string, fields: Array<ScalarField | ObjectField>,  documentation?: string, map?: string): Model;
export function createModel(options: CreateModelOptions): Model;
```
