### PR TITLE
refactor(builder): now accept options object arguments

### DIFF
--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -1,0 +1,29 @@
+import { parseArgs } from "./utils";
+
+describe("parseArgs", () => {
+  test("should be able to parse variadic arguments #1", () => {
+    type MyObject = {
+      success: boolean;
+      type: string;
+      code: number;
+    };
+    const args = [true, "bigSuccess", 200];
+
+    const result = parseArgs<MyObject>(args, ["success", "type", "code"]);
+
+    expect(result).toEqual({ success: true, type: "bigSuccess", code: 200 });
+  });
+
+  test("should be able to parse an options object", () => {
+    type MyObject = {
+      success: boolean;
+      type: string;
+      code: number;
+    };
+    const args: [MyObject] = [{ success: true, type: "bigSuccess", code: 200 }];
+
+    const result = parseArgs<MyObject>(args, ["success", "type", "code"]);
+
+    expect(result).toEqual({ success: true, type: "bigSuccess", code: 200 });
+  });
+});

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -1,7 +1,7 @@
 import { parseArgs } from "./utils";
 
 describe("parseArgs", () => {
-  test("should be able to parse variadic arguments #1", () => {
+  test("should be able to parse variadic arguments", () => {
     type MyObject = {
       success: boolean;
       type: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,16 @@
+export function parseArgs<O extends object>(
+  args: [O] | Array<O[keyof O]>,
+  propNames: Array<keyof O>
+): O {
+  const isOptionsObj = args.length === 1 && typeof args[0] === "object";
+
+  if (isOptionsObj) return args[0] as O;
+
+  return propNames.reduce((acc: O, p, index) => {
+    acc[p] = isOptionsObj
+      ? (args[0] as O)[p]
+      : (args as Array<O[keyof O]>)[index];
+
+    return acc;
+  }, {} as O);
+}


### PR DESCRIPTION
## Changes
This PR modifies the function signature of the builder functions to accept a single options object as an argument, which is a more flexible and extensible pattern. This approach allows for easier addition of new configuration options in the future without having to modify the function signature.

The options object pattern adds the benefit of reducing the number of parameters a function accepts, making the function call more concise and readable. It also allows for the optional configuration of parameters that previously had to be specified in a specific order, leading to better maintainability and code reusability.

The changes are backward-compatible, meaning that existing code that uses the old signature will continue to work as before. However, the old signature has been marked as 'deprecated', indicating that it is no longer the recommended way to call the function.

### Example
```ts
// new way of passing options
createDataSource({ name: "myDataSource", provider: DataSourceProvider.MongoDB, URL: "", });
// old signature is still supported
createDataSource("myDataSource", DataSourceProvider.MongoDB, "");
```


### Notes
After this PR, each function now has two different signatures to support both the new options object pattern and the old variadic arguments pattern. This makes the code more verbose and harder to maintain. It may be worth considering breaking compatibility with the old signature in the next major version of the module and only supporting the single options object pattern. This will simplify the codebase and make it easier to maintain in the long run.