### PR TITLE
feat: add support for custom attributes on model and field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@types/jest": "^26.0.19",
         "jest": "^26.6.3",
         "prettier": "^2.2.1",
-        "prisma-schema-dsl-types": "^1.0.8",
+        "prisma-schema-dsl-types": "^1.1.0",
         "ts-jest": "^26.4.4",
         "ts-toolbelt": "^9.6.0"
       }
@@ -5571,9 +5571,9 @@
       }
     },
     "node_modules/prisma-schema-dsl-types": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/prisma-schema-dsl-types/-/prisma-schema-dsl-types-1.0.8.tgz",
-      "integrity": "sha512-rR/3abzaev62MX7UMJWBIcFXG2oE/epGPR3pa64GoTGs4N2z6kMkF1RmMezvYoexM+UGYkcQQgYljkQcvzwmSA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/prisma-schema-dsl-types/-/prisma-schema-dsl-types-1.1.0.tgz",
+      "integrity": "sha512-EYYZYvAS4+T26KJgL1MGKmU2h4tHoMiMfL4t5TZz9B0z/Fxj0ir4k9oftuSggdZAv1mMuOKCHAbE06V6DTnXVQ==",
       "dev": true,
       "dependencies": {
         "typescript": "^4.9.3"
@@ -12062,9 +12062,9 @@
       }
     },
     "prisma-schema-dsl-types": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/prisma-schema-dsl-types/-/prisma-schema-dsl-types-1.0.8.tgz",
-      "integrity": "sha512-rR/3abzaev62MX7UMJWBIcFXG2oE/epGPR3pa64GoTGs4N2z6kMkF1RmMezvYoexM+UGYkcQQgYljkQcvzwmSA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/prisma-schema-dsl-types/-/prisma-schema-dsl-types-1.1.0.tgz",
+      "integrity": "sha512-EYYZYvAS4+T26KJgL1MGKmU2h4tHoMiMfL4t5TZz9B0z/Fxj0ir4k9oftuSggdZAv1mMuOKCHAbE06V6DTnXVQ==",
       "dev": true,
       "requires": {
         "typescript": "^4.9.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prisma-schema-dsl",
-  "version": "2.0.7",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "prisma-schema-dsl",
-      "version": "2.0.7",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@prisma/internals": "^4.6.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@types/jest": "^26.0.19",
     "jest": "^26.6.3",
     "prettier": "^2.2.1",
-    "prisma-schema-dsl-types": "^1.0.8",
+    "prisma-schema-dsl-types": "^1.1.0",
     "ts-jest": "^26.4.4",
     "ts-toolbelt": "^9.6.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-schema-dsl",
-  "version": "2.0.7",
+  "version": "2.1.0",
   "description": "JavaScript interface for Prisma Schema DSL",
   "main": "dist/index.js",
   "scripts": {

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -23,6 +23,12 @@ const NAME_REGEXP = /[A-Za-z][A-Za-z0-9_]*/;
 export const OPTIONAL_LIST_ERROR_MESSAGE =
   "Invalid modifiers: You cannot combine isRequired: false and isList: true - optional lists are not supported.";
 
+export const INVALID_MODEL_ATTRIBUTES_ERROR_MESSAGE =
+  "Invalid model attribute: all model attributes must start with @@.";
+
+export const INVALID_FIELD_ATTRIBUTES_ERROR_MESSAGE =
+  "Invalid field attribute: all field attributes must start with @.";
+
 /** Creates a schema AST object */
 export function createSchema(
   models: Model[],
@@ -57,14 +63,17 @@ export function createModel(
   name: string,
   fields: Array<ScalarField | ObjectField>,
   documentation?: string,
-  map?: string
+  map?: string,
+  attributes?: string | string[]
 ): Model {
   validateName(name);
+  const preparedAttributes = validateAndPrepareModelAttributes(attributes);
   return {
     name,
     fields,
     documentation,
     map,
+    attributes: preparedAttributes,
   };
 }
 
@@ -82,11 +91,13 @@ export function createScalarField(
   isUpdatedAt: boolean = false,
   defaultValue: ScalarFieldDefault = null,
   documentation?: string,
-  isForeignKey: boolean = false
+  isForeignKey: boolean = false,
+  attributes?: string | string[]
 ): ScalarField {
   validateName(name);
   validateScalarDefault(type, defaultValue);
   validateModifiers(isRequired, isList);
+  const preparedAttributes = validateAndPrepareFieldAttributes(attributes);
   return {
     name,
     isList,
@@ -99,6 +110,7 @@ export function createScalarField(
     default: defaultValue,
     documentation,
     isForeignKey,
+    attributes: preparedAttributes,
   };
 }
 
@@ -185,10 +197,12 @@ export function createObjectField(
   relationReferences: string[] = [],
   relationOnDelete: ReferentialActions = ReferentialActions.NONE,
   relationOnUpdate: ReferentialActions = ReferentialActions.NONE,
-  documentation?: string
+  documentation?: string,
+  attributes?: string | string[]
 ): ObjectField {
   validateName(name);
   validateModifiers(isRequired, isList);
+  const preparedAttributes = validateAndPrepareFieldAttributes(attributes);
 
   return {
     name,
@@ -202,6 +216,7 @@ export function createObjectField(
     relationOnDelete,
     relationOnUpdate,
     documentation,
+    attributes: preparedAttributes,
   };
 }
 
@@ -217,6 +232,56 @@ function validateModifiers(isRequired: boolean, isList: boolean): void {
   if (!isRequired && isList) {
     throw new Error(OPTIONAL_LIST_ERROR_MESSAGE);
   }
+}
+
+function validateAndPrepareModelAttributes(
+  attributes?: string | string[]
+): string[] | null {
+  if (!attributes) {
+    return null;
+  }
+
+  if (typeof attributes === "string") {
+    attributes = attributes.split("@@");
+    attributes = attributes.map((attribute) =>
+      attribute.length ? `@@${attribute}`.trim() : ""
+    );
+    attributes.shift();
+  }
+
+  if (
+    !Array.isArray(attributes) ||
+    !attributes.every((attribute) => attribute.startsWith("@@"))
+  ) {
+    throw new Error(INVALID_MODEL_ATTRIBUTES_ERROR_MESSAGE);
+  }
+
+  return attributes;
+}
+
+function validateAndPrepareFieldAttributes(
+  attributes?: string | string[]
+): string[] | null {
+  if (!attributes) {
+    return null;
+  }
+
+  if (typeof attributes === "string") {
+    attributes = attributes.split("@");
+    attributes = attributes.map((attribute) =>
+      attribute.length ? `@${attribute}`.trim() : ""
+    );
+    attributes.shift();
+  }
+
+  if (
+    !Array.isArray(attributes) ||
+    !attributes.every((attribute) => attribute.startsWith("@"))
+  ) {
+    throw new Error(INVALID_FIELD_ATTRIBUTES_ERROR_MESSAGE);
+  }
+
+  return attributes;
 }
 
 /** Creates a data source AST object */

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -234,7 +234,9 @@ function validateModifiers(isRequired: boolean, isList: boolean): void {
   }
 }
 
-function validateAndPrepareModelAttributes(
+function validateAndPrepareAttributesPrefix(
+  attributePrefix: string,
+  invalidErrorMessage: string,
   attributes?: string | string[]
 ): string[] | null {
   if (!attributes) {
@@ -242,46 +244,48 @@ function validateAndPrepareModelAttributes(
   }
 
   if (typeof attributes === "string") {
-    attributes = attributes.split("@@");
-    attributes = attributes.map((attribute) =>
-      attribute.length ? `@@${attribute}`.trim() : ""
+    // split by new lines or empty strings first
+    attributes = attributes.split(/\s+/);
+    // flatten the array and split each string by attributePrefix only if it contains attributePrefix
+    attributes = attributes.flatMap((attribute) =>
+      attribute.includes(attributePrefix)
+        ? attribute
+            .split(attributePrefix)
+            .filter(Boolean) // Remove empty strings
+            .map((attr) => attributePrefix + attr.trim())
+        : attribute.trim()
     );
-    attributes.shift();
   }
 
+  // Check if it's an array and if all attributes start with the prefix
   if (
     !Array.isArray(attributes) ||
-    !attributes.every((attribute) => attribute.startsWith("@@"))
+    !attributes.every((attribute) => attribute.startsWith(attributePrefix))
   ) {
-    throw new Error(INVALID_MODEL_ATTRIBUTES_ERROR_MESSAGE);
+    throw new Error(invalidErrorMessage);
   }
 
   return attributes;
 }
 
+function validateAndPrepareModelAttributes(
+  attributes?: string | string[]
+): string[] | null {
+  return validateAndPrepareAttributesPrefix(
+    "@@",
+    INVALID_MODEL_ATTRIBUTES_ERROR_MESSAGE,
+    attributes
+  );
+}
+
 function validateAndPrepareFieldAttributes(
   attributes?: string | string[]
 ): string[] | null {
-  if (!attributes) {
-    return null;
-  }
-
-  if (typeof attributes === "string") {
-    attributes = attributes.split("@");
-    attributes = attributes.map((attribute) =>
-      attribute.length ? `@${attribute}`.trim() : ""
-    );
-    attributes.shift();
-  }
-
-  if (
-    !Array.isArray(attributes) ||
-    !attributes.every((attribute) => attribute.startsWith("@"))
-  ) {
-    throw new Error(INVALID_FIELD_ATTRIBUTES_ERROR_MESSAGE);
-  }
-
-  return attributes;
+  return validateAndPrepareAttributesPrefix(
+    "@",
+    INVALID_FIELD_ATTRIBUTES_ERROR_MESSAGE,
+    attributes
+  );
 }
 
 /** Creates a data source AST object */

--- a/src/print.spec.ts
+++ b/src/print.spec.ts
@@ -415,6 +415,26 @@ describe("printField", () => {
   test.each(cases)("%s", (name, field, expected) => {
     expect(printField(field, POSTGRES_SQL_PROVIDER)).toBe(expected);
   });
+
+  test("Throws error when a field attribute doesn't start with '@'", () => {
+    expect(() =>
+      createScalarField(
+        EXAMPLE_FIELD_NAME,
+        ScalarType.String,
+        false,
+        true,
+        false,
+        false,
+        false,
+        undefined,
+        undefined,
+        false,
+        ["@attr1", "@attr2", "attr3", "\n\nattr4"]
+      )
+    ).toThrow(
+      "Invalid field attribute: all field attributes must start with @."
+    );
+  });
 });
 
 describe("printModel", () => {
@@ -484,6 +504,19 @@ ${printField(EXAMPLE_OTHER_STRING_FIELD, POSTGRES_SQL_PROVIDER)}
   ];
   test.each(cases)("%s", (name, model, expected) => {
     expect(printModel(model, POSTGRES_SQL_PROVIDER)).toBe(expected);
+  });
+  test("Throws error when a model attribute doesn't start with '@@'", () => {
+    expect(() =>
+      createModel(EXAMPLE_MODEL_NAME, [EXAMPLE_STRING_FIELD], "", undefined, [
+        "@@id(fields: [title, author])",
+        "@@createdAt",
+        "@updatedAt",
+        "invalid",
+        "\n\ninvalid2",
+      ])
+    ).toThrow(
+      "Invalid model attribute: all model attributes must start with @@."
+    );
   });
 });
 

--- a/src/print.spec.ts
+++ b/src/print.spec.ts
@@ -45,6 +45,9 @@ const EXAMPLE_STRING_FIELD = createScalarField(
   false,
   true
 );
+
+const EXAMPLE_FIELD_ATTRIBUTES = ["@attr1", "@attr2", "@attr3"];
+
 const EXAMPLE_OTHER_STRING_FIELD = createScalarField(
   "exampleOtherFieldName",
   ScalarType.String,
@@ -115,26 +118,70 @@ describe("printField", () => {
         false,
         false,
         undefined,
-        EXAMPLE_DOCUMENTATION
+        EXAMPLE_DOCUMENTATION,
+        undefined,
+        EXAMPLE_FIELD_ATTRIBUTES
       ),
       `${printDocumentation(EXAMPLE_DOCUMENTATION)}\n${EXAMPLE_FIELD_NAME} ${
         ScalarType.String
-      }`,
+      } ${EXAMPLE_FIELD_ATTRIBUTES.join(" ")}`,
     ],
     [
       "Simple float field",
-      createScalarField(EXAMPLE_FIELD_NAME, ScalarType.Float, false, true),
-      `${EXAMPLE_FIELD_NAME} ${ScalarType.Float}`,
+      createScalarField(
+        EXAMPLE_FIELD_NAME,
+        ScalarType.Float,
+        false,
+        true,
+        false,
+        false,
+        false,
+        null,
+        undefined,
+        false,
+        EXAMPLE_FIELD_ATTRIBUTES
+      ),
+      `${EXAMPLE_FIELD_NAME} ${
+        ScalarType.Float
+      } ${EXAMPLE_FIELD_ATTRIBUTES.join(" ")}`,
     ],
     [
       "Simple optional string field",
-      createScalarField(EXAMPLE_FIELD_NAME, ScalarType.String, false, false),
-      `${EXAMPLE_FIELD_NAME} ${ScalarType.String}?`,
+      createScalarField(
+        EXAMPLE_FIELD_NAME,
+        ScalarType.String,
+        false,
+        false,
+        false,
+        false,
+        false,
+        null,
+        undefined,
+        false,
+        EXAMPLE_FIELD_ATTRIBUTES
+      ),
+      `${EXAMPLE_FIELD_NAME} ${
+        ScalarType.String
+      }? ${EXAMPLE_FIELD_ATTRIBUTES.join(" ")}`,
     ],
     [
       "Simple string array field",
-      createScalarField(EXAMPLE_FIELD_NAME, ScalarType.String, true, true),
-      `${EXAMPLE_FIELD_NAME} ${ScalarType.String}[]`,
+      createScalarField(
+        EXAMPLE_FIELD_NAME,
+        ScalarType.String,
+        true,
+        true,
+        false,
+        false,
+        false,
+        null,
+        undefined,
+        false,
+        EXAMPLE_FIELD_ATTRIBUTES
+      ),
+      `${EXAMPLE_FIELD_NAME} ${
+        ScalarType.String
+      }[] ${EXAMPLE_FIELD_ATTRIBUTES.join(" ")}`,
     ],
     [
       "Simple date-time field",
@@ -145,9 +192,15 @@ describe("printField", () => {
         true,
         false,
         false,
-        false
+        false,
+        null,
+        undefined,
+        false,
+        EXAMPLE_FIELD_ATTRIBUTES
       ),
-      `${EXAMPLE_FIELD_NAME} ${ScalarType.DateTime}`,
+      `${EXAMPLE_FIELD_NAME} ${
+        ScalarType.DateTime
+      } ${EXAMPLE_FIELD_ATTRIBUTES.join(" ")}`,
     ],
     [
       "Int field with default",
@@ -159,9 +212,14 @@ describe("printField", () => {
         false,
         false,
         false,
-        42
+        42,
+        undefined,
+        false,
+        EXAMPLE_FIELD_ATTRIBUTES
       ),
-      `${EXAMPLE_FIELD_NAME} ${ScalarType.Int} @default(42)`,
+      `${EXAMPLE_FIELD_NAME} ${
+        ScalarType.Int
+      } @default(42) ${EXAMPLE_FIELD_ATTRIBUTES.join(" ")}`,
     ],
     [
       "Int field with autoincrement()",
@@ -173,9 +231,14 @@ describe("printField", () => {
         false,
         false,
         false,
-        { callee: AUTO_INCREMENT }
+        { callee: AUTO_INCREMENT },
+        undefined,
+        false,
+        EXAMPLE_FIELD_ATTRIBUTES
       ),
-      `${EXAMPLE_FIELD_NAME} ${ScalarType.Int} @default(autoincrement())`,
+      `${EXAMPLE_FIELD_NAME} ${
+        ScalarType.Int
+      } @default(autoincrement()) ${EXAMPLE_FIELD_ATTRIBUTES.join(" ")}`,
     ],
     [
       "String field with uuid()",
@@ -187,9 +250,14 @@ describe("printField", () => {
         false,
         false,
         false,
-        { callee: UUID }
+        { callee: UUID },
+        undefined,
+        false,
+        EXAMPLE_FIELD_ATTRIBUTES
       ),
-      `${EXAMPLE_FIELD_NAME} ${ScalarType.String} @default(uuid())`,
+      `${EXAMPLE_FIELD_NAME} ${
+        ScalarType.String
+      } @default(uuid()) ${EXAMPLE_FIELD_ATTRIBUTES.join(" ")}`,
     ],
     [
       "String field with cuid()",
@@ -201,9 +269,14 @@ describe("printField", () => {
         false,
         false,
         false,
-        { callee: CUID }
+        { callee: CUID },
+        undefined,
+        false,
+        EXAMPLE_FIELD_ATTRIBUTES
       ),
-      `${EXAMPLE_FIELD_NAME} ${ScalarType.String} @default(cuid())`,
+      `${EXAMPLE_FIELD_NAME} ${
+        ScalarType.String
+      } @default(cuid()) ${EXAMPLE_FIELD_ATTRIBUTES.join(" ")}`,
     ],
     [
       "Date-time field with now()",
@@ -215,9 +288,14 @@ describe("printField", () => {
         false,
         false,
         false,
-        { callee: NOW }
+        { callee: NOW },
+        undefined,
+        false,
+        EXAMPLE_FIELD_ATTRIBUTES
       ),
-      `${EXAMPLE_FIELD_NAME} ${ScalarType.DateTime} @default(now())`,
+      `${EXAMPLE_FIELD_NAME} ${
+        ScalarType.DateTime
+      } @default(now()) ${EXAMPLE_FIELD_ATTRIBUTES.join(" ")}`,
     ],
     [
       "Boolean field with default value",
@@ -229,14 +307,33 @@ describe("printField", () => {
         false,
         false,
         false,
-        true
+        true,
+        undefined,
+        false,
+        EXAMPLE_FIELD_ATTRIBUTES
       ),
-      `${EXAMPLE_FIELD_NAME} ${ScalarType.Boolean} @default(true)`,
+      `${EXAMPLE_FIELD_NAME} ${
+        ScalarType.Boolean
+      } @default(true) ${EXAMPLE_FIELD_ATTRIBUTES.join(" ")}`,
     ],
     [
       "Simple object field",
-      createObjectField(EXAMPLE_FIELD_NAME, EXAMPLE_OBJECT_NAME, false, true),
-      `${EXAMPLE_FIELD_NAME} ${EXAMPLE_OBJECT_NAME}`,
+      createObjectField(
+        EXAMPLE_FIELD_NAME,
+        EXAMPLE_OBJECT_NAME,
+        false,
+        true,
+        null,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        EXAMPLE_FIELD_ATTRIBUTES
+      ),
+      `${EXAMPLE_FIELD_NAME} ${EXAMPLE_OBJECT_NAME} ${EXAMPLE_FIELD_ATTRIBUTES.join(
+        " "
+      )}`,
     ],
     [
       "Object field with relation",
@@ -245,9 +342,17 @@ describe("printField", () => {
         EXAMPLE_OBJECT_NAME,
         false,
         true,
-        EXAMPLE_RELATION_NAME
+        EXAMPLE_RELATION_NAME,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        EXAMPLE_FIELD_ATTRIBUTES
       ),
-      `${EXAMPLE_FIELD_NAME} ${EXAMPLE_OBJECT_NAME} @relation(name: "${EXAMPLE_RELATION_NAME}")`,
+      `${EXAMPLE_FIELD_NAME} ${EXAMPLE_OBJECT_NAME} @relation(name: "${EXAMPLE_RELATION_NAME}") ${EXAMPLE_FIELD_ATTRIBUTES.join(
+        " "
+      )}`,
     ],
     [
       "Object field with fields",
@@ -257,9 +362,16 @@ describe("printField", () => {
         false,
         true,
         null,
-        [EXAMPLE_RELATION_FIELD_NAME]
+        [EXAMPLE_RELATION_FIELD_NAME],
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        EXAMPLE_FIELD_ATTRIBUTES
       ),
-      `${EXAMPLE_FIELD_NAME} ${EXAMPLE_OBJECT_NAME} @relation(fields: [${EXAMPLE_RELATION_FIELD_NAME}])`,
+      `${EXAMPLE_FIELD_NAME} ${EXAMPLE_OBJECT_NAME} @relation(fields: [${EXAMPLE_RELATION_FIELD_NAME}]) ${EXAMPLE_FIELD_ATTRIBUTES.join(
+        " "
+      )}`,
     ],
     [
       "Object field with references",
@@ -270,9 +382,15 @@ describe("printField", () => {
         true,
         null,
         [],
-        [EXAMPLE_RELATION_REFERENCE_FIELD_NAME]
+        [EXAMPLE_RELATION_REFERENCE_FIELD_NAME],
+        undefined,
+        undefined,
+        undefined,
+        EXAMPLE_FIELD_ATTRIBUTES
       ),
-      `${EXAMPLE_FIELD_NAME} ${EXAMPLE_OBJECT_NAME} @relation(references: [${EXAMPLE_RELATION_REFERENCE_FIELD_NAME}])`,
+      `${EXAMPLE_FIELD_NAME} ${EXAMPLE_OBJECT_NAME} @relation(references: [${EXAMPLE_RELATION_REFERENCE_FIELD_NAME}]) ${EXAMPLE_FIELD_ATTRIBUTES.join(
+        " "
+      )}`,
     ],
     [
       "Object field with full relation",
@@ -283,9 +401,15 @@ describe("printField", () => {
         true,
         EXAMPLE_RELATION_NAME,
         [EXAMPLE_RELATION_FIELD_NAME],
-        [EXAMPLE_RELATION_REFERENCE_FIELD_NAME]
+        [EXAMPLE_RELATION_REFERENCE_FIELD_NAME],
+        undefined,
+        undefined,
+        undefined,
+        EXAMPLE_FIELD_ATTRIBUTES
       ),
-      `${EXAMPLE_FIELD_NAME} ${EXAMPLE_OBJECT_NAME} @relation(name: "${EXAMPLE_RELATION_NAME}", fields: [${EXAMPLE_RELATION_FIELD_NAME}], references: [${EXAMPLE_RELATION_REFERENCE_FIELD_NAME}])`,
+      `${EXAMPLE_FIELD_NAME} ${EXAMPLE_OBJECT_NAME} @relation(name: "${EXAMPLE_RELATION_NAME}", fields: [${EXAMPLE_RELATION_FIELD_NAME}], references: [${EXAMPLE_RELATION_REFERENCE_FIELD_NAME}]) ${EXAMPLE_FIELD_ATTRIBUTES.join(
+        " "
+      )}`,
     ],
   ];
   test.each(cases)("%s", (name, field, expected) => {
@@ -337,6 +461,24 @@ ${printField(EXAMPLE_OTHER_STRING_FIELD, POSTGRES_SQL_PROVIDER)}
 ${printField(EXAMPLE_STRING_FIELD, POSTGRES_SQL_PROVIDER)}
 
 ${printModelMap(EXAMPLE_MODEL_MAP)}
+}`,
+    ],
+    [
+      "with model attributes",
+      createModel(
+        EXAMPLE_MODEL_NAME,
+        [EXAMPLE_STRING_FIELD, EXAMPLE_OTHER_STRING_FIELD],
+        "",
+        undefined,
+        ["@@id(fields: [title, author])", "@@createdAt", "@@updatedAt"]
+      ),
+      `model ${EXAMPLE_MODEL_NAME} {
+${printField(EXAMPLE_STRING_FIELD, POSTGRES_SQL_PROVIDER)}
+${printField(EXAMPLE_OTHER_STRING_FIELD, POSTGRES_SQL_PROVIDER)}
+
+@@id(fields: [title, author])
+@@createdAt
+@@updatedAt
 }`,
     ],
   ];

--- a/src/print.ts
+++ b/src/print.ts
@@ -133,10 +133,19 @@ export function printModel(
     .join("\n");
   const map = model.map ? printModelMap(model.map, true) : "";
 
+  const attributesText = printModelAttributes(model.attributes);
+
   return withDocumentation(
     model.documentation,
-    `model ${model.name} {\n${fieldTexts}${map}\n}`
+    `model ${model.name} {\n${fieldTexts}${map}\n${attributesText}}`
   );
+}
+
+export function printModelAttributes(attributes?: string[] | null): string {
+  if (!attributes || attributes.length === 0) {
+    return "";
+  }
+  return `\n${attributes.join("\n")}\n`;
 }
 
 /**
@@ -192,6 +201,8 @@ function printScalarField(
     }
   }
 
+  Array.isArray(field.attributes) && attributes.push(...field.attributes);
+
   const typeText = `${field.type}${modifiersText}`;
   const attributesText = attributes.join(" ");
   return [field.name, typeText, attributesText].filter(Boolean).join(" ");
@@ -229,6 +240,9 @@ function printObjectField(field: ObjectField): string {
   if (!isEmpty(relation)) {
     attributes.push(printRelation(relation, field));
   }
+
+  Array.isArray(field.attributes) && attributes.push(...field.attributes);
+
   const typeText = `${field.type}${printFieldModifiers(field)}`;
   const attributesText = attributes.join(" ");
   return [field.name, typeText, attributesText].filter(Boolean).join(" ");


### PR DESCRIPTION
part of https://github.com/amplication/amplication/issues/5989

Depends on https://github.com/amplication/prisma-schema-dsl-types/pull/5

## PR Details

Add support for adding custom attributes on fields and models.



The attributes can be provided to the builder either as a single string or as a string[]

The attributes are concatenated to any other attributes. 

The following are not part of this PR and can be added seperatly based on actual needs:
1. Validate the values of the attributes against Prisma spec
2. Validate and avoid duplicate attributes 

